### PR TITLE
Merchant dashboard us12

### DIFF
--- a/app/controllers/merchant/discounts_controller.rb
+++ b/app/controllers/merchant/discounts_controller.rb
@@ -5,6 +5,14 @@ class Merchant::DiscountsController < Merchant::BaseController
     @discounts = @merchant.discounts
   end
 
+  def destroy
+    merchant = current_user.merchant
+    discount = Discount.find(params[:id])
+    merchant.discounts.destroy(discount.id)
+    discount.destroy
+    redirect_to "/merchant/discounts"
+  end
+
   def edit
     @discount = Discount.find(params[:id])
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :new, :create, :edit, :update, :destroy]
     put '/items/:id/change_status', to: 'items#change_status'
     get '/orders/:id/fulfill/:order_item_id', to: 'orders#fulfill'
-    resources :discounts, only: [:index, :show, :new, :create, :edit]
+    resources :discounts, only: [:index, :show, :new, :create, :edit, :destroy]
     patch '/discounts/:id', to: 'discounts#update', as: :discount_update
     patch '/discounts/:status/:id', to: 'discounts#update_status'
   end

--- a/spec/features/merchant/discounts/show_spec.rb
+++ b/spec/features/merchant/discounts/show_spec.rb
@@ -36,5 +36,22 @@ RSpec.describe 'Discounts Show Page under Merchant Dashboard' do
       expect(page).to have_button("Enable this Discount")
       expect(page).to have_button("Edit this Discount")
     end
+
+    it "can delete a discount" do
+      visit '/merchant/discounts'
+      within "#discount-info-#{@merchant_1_discount_2.id}" do
+        expect(page).to have_link("Discount# #{@merchant_1_discount_2.id}")
+        expect(page).to have_button("Delete this Discount")
+        expect(page).to have_content("Status: Enabled")
+        click_link "Discount# #{@merchant_1_discount_2.id}"
+      end
+
+      expect(current_path).to eq("/merchant/discounts/#{@merchant_1_discount_2.id}")
+
+      expect(page).to have_button("Delete this Discount")
+      click_button "Delete this Discount"
+      expect(page).to_not have_link("Discount# #{@merchant_1_discount_2.id}")
+      expect(current_path).to eq("/merchant/discounts")
+    end
   end
 end


### PR DESCRIPTION
Closes #18 

As a merchant user
When I visit /merchant/discounts/show
When I click the link to delete the discount
I am taken to the discount index page
Where I no longer see that discounts id and information