### PR TITLE
Merchant dashboard us7

### DIFF
--- a/app/controllers/merchant/discounts_controller.rb
+++ b/app/controllers/merchant/discounts_controller.rb
@@ -46,26 +46,15 @@ class Merchant::DiscountsController < Merchant::BaseController
     end
   end
 
-
-  # def update_status
-  #   discount = Discount.find(params[:id])
-  #   if params[:status] == "disable"
-  #     discount.update!(enable:false)
-  #   elsif params[:status] == "enable"
-  #     discount.update!(enable:true)
-  #   end
-  #   redirect_to request.referer
-  # end
-
-  # def update_status
-  #   discount = Discount.find(params[:id])
-  #   if params[:status] == "disable"
-  #     Discount.where(id:discount.id).update(enable:false)
-  #   elsif params[:status] == "enable"
-  #     Discount.where(id:discount.id).update(enable:true)
-  #   end
-  #   redirect_to request.referer
-  # end
+  def update_status
+    discount = Discount.find(params[:id])
+    if params[:status] == "disable"
+      discount.update(enable:false)
+    elsif params[:status] == "enable"
+      discount.update(enable:true)
+    end
+    redirect_to "/merchant/discounts/#{discount.id}"
+  end
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,8 +39,8 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :new, :create, :edit, :update, :destroy]
     put '/items/:id/change_status', to: 'items#change_status'
     get '/orders/:id/fulfill/:order_item_id', to: 'orders#fulfill'
-    resources :discounts, only: [:index, :show, :new, :create, :edit, :destroy]
-    patch '/discounts/:id', to: 'discounts#update', as: :discount_update
+    resources :discounts, only: [:index, :show, :new, :create, :edit, :destroy, :update]
+    # patch '/discounts/:id', to: 'discounts#update', as: :discount_update
     patch '/discounts/:status/:id', to: 'discounts#update_status'
   end
 

--- a/spec/features/merchant/discounts/index_spec.rb
+++ b/spec/features/merchant/discounts/index_spec.rb
@@ -39,24 +39,20 @@ RSpec.describe 'Discounts Index Page under Merchant Dashboard' do
       end
     end
 
-    xit "can enable or disable a discount from index page" do
+    it "can enable or disable a discount from index page" do
       visit '/merchant/discounts'
 
       within "#discount-info-#{@merchant_1_discount_2.id}" do
         expect(page).to have_content("Status: Enabled")
         expect(page).to have_button("Disable this Discount")
-        expect(@merchant_1_discount_2.enable).to eq(true)
 
         click_button "Disable this Discount"
       end
 
-      expect(current_path).to eq("/merchant/discounts")
+      expect(current_path).to eq("/merchant/discounts/#{@merchant_1_discount_2.id}")
 
-      within "#discount-info-#{@merchant_1_discount_2.id}" do
-        expect(page).to have_content("Status: Disabled")
-        expect(page).to have_button("Enable this Discount")
-        expect(@merchant_1_discount_2.enable).to eq(false)
-      end
+      expect(page).to have_content("Status: Disabled")
+      expect(page).to have_button("Enable this Discount")
     end
 
     it "can visit a unique discount show page by clicking id" do


### PR DESCRIPTION
Closes #13 
As a merchant user
When I visit /merchant/discounts
I see a enabled/disabled check box that can be updated
When I click the check_box for enable/disable and save
I am redirected to the discount show page where I can see the status is updated