### PR TITLE
Add test for US 9 - enable disable is visible on show page as well

### DIFF
--- a/spec/features/merchant/discounts/show_spec.rb
+++ b/spec/features/merchant/discounts/show_spec.rb
@@ -53,5 +53,16 @@ RSpec.describe 'Discounts Show Page under Merchant Dashboard' do
       expect(page).to_not have_link("Discount# #{@merchant_1_discount_2.id}")
       expect(current_path).to eq("/merchant/discounts")
     end
+
+    it "can enable or disable a discount from show page" do
+      visit "/merchant/discounts/#{@merchant_1_discount_1.id}"
+
+        expect(page).to have_content("Status: Disabled")
+        expect(page).to have_button("Enable this Discount")
+        click_button "Enable this Discount"
+
+        expect(page).to have_content("Status: Enabled")
+        expect(page).to have_button("Disable this Discount")
+    end
   end
 end


### PR DESCRIPTION
Closes #15 

As a merchant user
When I visit /merchant/discounts/show
I see a enabled/disabled check box that can be updated
When I click the check_box for enable/disable and save
The page is refreshed
I now see the updated status of the discount