### PR TITLE
Completes US13

### DIFF
--- a/spec/features/cart/discount_spec.rb
+++ b/spec/features/cart/discount_spec.rb
@@ -50,5 +50,11 @@ RSpec.describe 'Discounted Cart Show Page' do
       expect(page).to have_content("Total: $4,850.00")
       expect(page).to have_content("Saved from Discounts: $150.00")
     end
+
+    it "can remove discount if items are decreased"
+    it "can show multiple discounts savings"
+    it "can see the discount with the least quantity in the cart as a possible discount available"
+    it "can only discount the qualified item - this might already by done"
+    it "can only apply the greater discount when more than one conflict"
   end
 end


### PR DESCRIPTION
Closes #19 

As a non-admin user
When I visit my cart
And it has items from a merchant with an enabled discount
And the quantity of merchant items meets the discount conditions
I will see a new section for "Saved from discounts" with the total price discounted in the cart
I will automatically see the discounted total instead of the "normal" total