### PR TITLE
Cart update 16

### DIFF
--- a/spec/features/cart/discount_spec.rb
+++ b/spec/features/cart/discount_spec.rb
@@ -117,9 +117,6 @@ RSpec.describe 'Discounted Cart Show Page' do
       expect(page).to have_content("Saved from Discounts: $650.00")
     end
 
-    it "can discount only bulk quantity items and not normal merchant items" do
-    end
-
     it "can only apply the greater discount when more than one conflict"
   end
 end

--- a/spec/features/cart/discount_spec.rb
+++ b/spec/features/cart/discount_spec.rb
@@ -91,9 +91,35 @@ RSpec.describe 'Discounted Cart Show Page' do
       end
     end
 
+    it "can discount multiple qualifying items from multiple merchants" do
+      visit '/cart'
 
-    it "can show multiple discounts savings"
-    it "can only discount the qualified item - this might already by done"
+      expect(page).to have_content("Total: $3,500.00")
+
+      within "#item-#{@ogre.id}" do
+        click_button('More of This!')
+      end
+
+      within "#item-#{@ogre.id}" do
+        expect(page).to have_content("Quantity: 5")
+      end
+
+      within "#item-#{@hippo.id}" do
+        click_button('More of This!')
+      end
+
+      within "#item-#{@hippo.id}" do
+        expect(page).to have_content("Quantity: 2")
+      end
+
+      expect(page).to_not have_content("Total: $5,500.00")
+      expect(page).to have_content("Total: $4,850.00")
+      expect(page).to have_content("Saved from Discounts: $650.00")
+    end
+
+    it "can discount only bulk quantity items and not normal merchant items" do
+    end
+
     it "can only apply the greater discount when more than one conflict"
   end
 end


### PR DESCRIPTION
Closes #22 

As a non-admin user
When I visit my cart
And it has items from a merchant with an enabled discount
And the quantity of merchant items meets the discount conditions
I will see a new section for "Saved from discounts" with the total price discounted in the cart
I will automatically see the discounted total instead of the "normal" total
This discounted price will only take a percentage off the bulk item and not a percentage off the total amount in the cart