### PR TITLE
Cart update 17

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -65,12 +65,27 @@ class Cart
     merchant = Merchant.find(item.merchant_id)
     merchant.discounts.order(:quantity).each do |discount|
       if quantity >= discount.quantity
-        @current_discount = discount
+        all_possible_discounts(item, quantity)
         return true
       else
         return false
       end
     end
+  end
+
+  def all_possible_discounts(item, quantity)
+    merchant = Merchant.find(item.merchant_id)
+    hash_for_discounted_totals = Hash.new
+    merchant.discounts.order(:quantity).each do |discount|
+      if quantity >= discount.quantity
+        multiplier = (100 - discount.percent).to_f / 100
+        current_total = item.price * quantity
+        discounted_total = current_total * multiplier
+        hash_for_discounted_totals[discount.id] = current_total - discounted_total
+      end
+    end
+    discount = Discount.find(hash_for_discounted_totals.key(hash_for_discounted_totals.values.max))
+    @current_discount = discount
   end
 
   def update_cart_with_discounts(discount, current_total)

--- a/spec/features/cart/discount_spec.rb
+++ b/spec/features/cart/discount_spec.rb
@@ -118,20 +118,31 @@ RSpec.describe 'Discounted Cart Show Page' do
     end
 
     it "can only apply the greater discount when more than one conflict" do
-      11.times do
+      visit item_path(@ogre)
+      click_button 'Add to Cart'
+
+      visit '/cart'
+
+      within "#item-#{@ogre.id}" do
+        expect(page).to have_content("Quantity: 5")
+      end
+
+      expect(page).to_not have_content("Total: $4,000.00")
+      expect(page).to have_content("Total: $3,500.00")
+      expect(page).to have_content("Saved from Discounts: $500.00")
+
+      10.times do
         visit item_path(@ogre)
         click_button 'Add to Cart'
       end
 
-      # 15 ogres + 1 hippo = 9000
-      # 15 ogres (original discount = 6000) + 1 hippo = 7500
-      # 15 ogres (correct discount = 4500) + 1 hippo = 6000
-
       visit '/cart'
 
-      #Original price
+      within "#item-#{@ogre.id}" do
+        expect(page).to have_content("Quantity: 15")
+      end
+
       expect(page).to_not have_content("Total: $9,000.00")
-      #Incorrect discount for buy 5, get 20% off
       expect(page).to_not have_content("Total: $7,500.00")
       expect(page).to have_content("Total: $6,000.00")
       expect(page).to have_content("Saved from Discounts: $3,000.00")

--- a/spec/features/cart/discount_spec.rb
+++ b/spec/features/cart/discount_spec.rb
@@ -117,6 +117,24 @@ RSpec.describe 'Discounted Cart Show Page' do
       expect(page).to have_content("Saved from Discounts: $650.00")
     end
 
-    it "can only apply the greater discount when more than one conflict"
+    it "can only apply the greater discount when more than one conflict" do
+      11.times do
+        visit item_path(@ogre)
+        click_button 'Add to Cart'
+      end
+
+      # 15 ogres + 1 hippo = 9000
+      # 15 ogres (original discount = 6000) + 1 hippo = 7500
+      # 15 ogres (correct discount = 4500) + 1 hippo = 6000
+
+      visit '/cart'
+
+      #Original price
+      expect(page).to_not have_content("Total: $9,000.00")
+      #Incorrect discount for buy 5, get 20% off
+      expect(page).to_not have_content("Total: $7,500.00")
+      expect(page).to have_content("Total: $6,000.00")
+      expect(page).to have_content("Saved from Discounts: $3,000.00")
+    end
   end
 end


### PR DESCRIPTION
Closes #23 

As a non-admin user
When I visit my cart
And it has items from a merchant with at least 2 enabled discounts
And the quantity of merchant items meets the the lower quantity discount condition
I will see a new section for "Saved from discounts" with the total price discounted in the cart
I will automatically see the discounted total instead of the "normal" total
If I update my items quantity to meet the higher quantity discount condition
The cart will calculate the greater of the 2 discounts
Apply only the greater to the cart total
I will see the new updated total with the greater discount applied (greater means a better value for the user)